### PR TITLE
fixed strpos() warning on link with empty url

### DIFF
--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -65,7 +65,11 @@ class NavWalker extends \Walker_Nav_Menu {
       }
     }
 
-    $element->is_active = strpos($this->archive, $element->url);
+    if ($element->url !== '') {
+      $element->is_active = strpos($this->archive, $element->url);
+    } else {
+      $element->is_active = false;
+    }
 
     if ($element->is_active) {
       $element->classes[] = 'active';


### PR DESCRIPTION
strpos() is giving a warning when the $needle is empty, which in this situation is the $element->url